### PR TITLE
Refactored Converter

### DIFF
--- a/app/src/main/java/com/example/complamap/model/ConverterListeners.kt
+++ b/app/src/main/java/com/example/complamap/model/ConverterListeners.kt
@@ -1,0 +1,16 @@
+package com.example.complamap.model
+
+import com.yandex.mapkit.GeoObject
+import com.yandex.runtime.Error
+interface OnAddressFetchedListener {
+
+    fun onSuccess(address: String?)
+
+    fun onError(error: Error) {}
+}
+interface OnGeoObjectFetchedListener {
+
+    fun onSuccess(obj: GeoObject?)
+
+    fun onError(error: Error) {}
+}

--- a/app/src/main/java/com/example/complamap/model/PointAddressConverter.kt
+++ b/app/src/main/java/com/example/complamap/model/PointAddressConverter.kt
@@ -1,15 +1,33 @@
 package com.example.complamap.model
 
+import android.util.Log
+import com.yandex.mapkit.GeoObject
 import com.yandex.mapkit.geometry.Point
 import com.yandex.mapkit.search.*
+import com.yandex.runtime.Error
 
 class PointAddressConverter(
-    listener: Session.SearchListener,
     searchType: Int
 ) { // На момент создания SearchFactory должна быть инициализирована
-    private val searchListener: Session.SearchListener = listener
     private val searchType: Int = searchType // Либо GEO(топоним), либо BIZ(организация)
     private var searchSession: Session? = null
+    private val searchListener: Session.SearchListener = object : Session.SearchListener {
+        override fun onSearchResponse(p0: Response) {
+            p0.collection.children.firstOrNull()?.let { it ->
+                onGeoObjectListener?.onSuccess(it.obj)
+                onAddressListener?.onSuccess(fetchAddress(it.obj!!))
+            }
+        }
+
+        override fun onSearchError(p0: Error) {
+            onAddressListener?.onError(p0)
+            onGeoObjectListener?.onError(p0)
+            Log.e("onSearchError", p0.toString())
+        }
+    }
+    private var onAddressListener: OnAddressFetchedListener? = null
+    private var onGeoObjectListener: OnGeoObjectFetchedListener? = null
+
     private val searchManager: SearchManager = SearchFactory
         .getInstance()
         .createSearchManager(SearchManagerType.ONLINE)
@@ -22,5 +40,32 @@ class PointAddressConverter(
                 SearchOptions().setSearchTypes(searchType),
                 searchListener
             )
+    }
+
+    fun addOnAddressFetchedListener(listener: OnAddressFetchedListener): Boolean {
+        onAddressListener = onAddressListener?.let { return false } ?: listener
+        return true
+    }
+    fun removeOnAddressFetchedListener() {
+        onAddressListener = null
+    }
+    fun addonGeoObjectFetchedListener(listener: OnGeoObjectFetchedListener): Boolean {
+        onGeoObjectListener = onGeoObjectListener?.let { return false } ?: listener
+        return true
+    }
+    fun removeGeoObjectFetchedListener() {
+        onGeoObjectListener = null
+    }
+    companion object {
+        fun fetchAddress(item: GeoObject): String? =
+            item.metadataContainer
+                .getItem(ToponymObjectMetadata::class.java)
+                ?.address?.formattedAddress
+                ?: let {
+                    item.metadataContainer
+                        .getItem(
+                            BusinessObjectMetadata::class.java
+                        )?.address?.formattedAddress
+                }
     }
 }

--- a/app/src/main/java/com/example/complamap/viewmodel/MapViewModel.kt
+++ b/app/src/main/java/com/example/complamap/viewmodel/MapViewModel.kt
@@ -1,9 +1,10 @@
 package com.example.complamap.viewmodel
 
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import com.example.complamap.model.OnAddressFetchedListener
+import com.example.complamap.model.OnGeoObjectFetchedListener
 import com.example.complamap.model.PointAddressConverter
 import com.yandex.mapkit.GeoObject
 import com.yandex.mapkit.geometry.Point
@@ -11,7 +12,6 @@ import com.yandex.mapkit.layers.GeoObjectTapEvent
 import com.yandex.mapkit.map.GeoObjectSelectionMetadata
 import com.yandex.mapkit.search.*
 import com.yandex.mapkit.search.search_layer.SearchResultItem
-import com.yandex.runtime.Error
 
 class MapViewModel : ViewModel() {
     private val addressMutable: MutableLiveData<String> = MutableLiveData()
@@ -19,22 +19,25 @@ class MapViewModel : ViewModel() {
     private val coordinatesMutable: MutableLiveData<String> = MutableLiveData()
     val coordinates: LiveData<String> = coordinatesMutable
     private val selectionMetadataMutable: MutableLiveData<GeoObjectSelectionMetadata> = MutableLiveData()
-    val selectionMetadata: LiveData<GeoObjectSelectionMetadata> get() = selectionMetadataMutable
-    private val pointAddressConverter = PointAddressConverter(
-        object : Session.SearchListener {
-            override fun onSearchResponse(p0: Response) {
-                p0.collection.children.firstOrNull()?.let { it ->
-                    fetchAddress(it.obj!!)?.let { updateAddress(it) }
-                    updateCoordinates(it.obj!!.geometry[0].point!!)
+    val selectionMetadata: LiveData<GeoObjectSelectionMetadata>
+        get() = selectionMetadataMutable
+    private val pointAddressConverter = PointAddressConverter(searchType = SearchType.GEO.value)
+        .apply {
+            addOnAddressFetchedListener(
+                object : OnAddressFetchedListener {
+                    override fun onSuccess(address: String?) {
+                        address?.let { updateAddress(it) }
+                    }
                 }
-            }
-
-            override fun onSearchError(p0: Error) {
-                Log.e("onSearchError", p0.toString())
-            }
-        },
-        searchType = SearchType.GEO.value
-    )
+            )
+            addonGeoObjectFetchedListener(
+                object : OnGeoObjectFetchedListener {
+                    override fun onSuccess(obj: GeoObject?) {
+                        obj?.geometry?.get(0)?.point?.let { updateCoordinates(it) }
+                    }
+                }
+            )
+        }
 
     fun processSelectedObject(p0: GeoObjectTapEvent) {
         val selectionMetadata = p0
@@ -54,22 +57,17 @@ class MapViewModel : ViewModel() {
     }
 
     fun processResultItem(item: SearchResultItem) {
-        fetchAddress(item.geoObject)?.let { updateAddress(it) }
+        PointAddressConverter.fetchAddress(item.geoObject)?.let { updateAddress(it) }
         updateCoordinates(item.point)
     }
 
-    private fun fetchAddress(item: GeoObject): String? =
-        item.metadataContainer
-            .getItem(ToponymObjectMetadata::class.java)
-            ?.address?.formattedAddress
-            ?: let {
-            item.metadataContainer
-                .getItem(
-                    BusinessObjectMetadata::class.java
-                )?.address?.formattedAddress
-        }
-
     fun addressFromPoint(p: Point, zoom: Int) {
         pointAddressConverter.addressFromPoint(p, zoom)
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        pointAddressConverter.removeGeoObjectFetchedListener()
+        pointAddressConverter.removeOnAddressFetchedListener()
     }
 }

--- a/app/src/main/java/com/example/complamap/views/fragments/MapFragment.kt
+++ b/app/src/main/java/com/example/complamap/views/fragments/MapFragment.kt
@@ -74,7 +74,8 @@ class MapFragment() : Fragment(), GeoObjectTapListener, InputListener, Placemark
                 override fun onEditorAction(
                     textView: TextView?,
                     actionId: Int,
-                    keyEvent: KeyEvent?): Boolean {
+                    keyEvent: KeyEvent?
+                ): Boolean {
                     val searchType = SearchType.GEO.value or SearchType.BIZ.value
                     if (actionId == EditorInfo.IME_ACTION_SEARCH) {
                         if (searchView.text.toString().isNotBlank() && searchView.text.toString().isNotEmpty()) {


### PR DESCRIPTION
Изменил класс конвертера.
Теперь, если вам надо получить адрес по точке создаёте класс конвертера 
PointAddressConverter(searchType = SearchType.GEO.value либо searchType = SearchType.BIZ.value).
Далее добавляете слушателя методом addOnAddressFetchedListener
В метод onSuccess слушателя передаётся полученный адрес (может быть null).
Также, если вам нужен geoObject по точке, добавьте слушателя методом addonGeoObjectFetchedListener
В onSuccess слушателя передаётся geoObject (может быть null).
В метод addressFromPoint(p: Point, zoom: Int) передаётся точка и зум. От зума на прямую зависит результат поиска.
Минимальные и максимальные значения зума есть в карте